### PR TITLE
Revert to akka 2.6.3 from 2.6.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ homepage := Some(url("https://github.com/flowcommerce/s3mock"))
 //   com.typesafe.akka:akka-actor-typed_2.13:2.6.3
 // pulled in by
 //   com.typesafe.play:play_2.13:2.8.1
-val akkaVersion = "2.6.8"
+val akkaVersion = "2.6.3"
 val akkaHttpVersion = "10.1.10"
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
Causes issues downstream in lib-s3 where it pulls in multiple versions if set above 2.6.3 (step 6 of DD)